### PR TITLE
Add kitty terminal support

### DIFF
--- a/sshmgr.cpp
+++ b/sshmgr.cpp
@@ -18,7 +18,7 @@ const char *logo =
 	"\033[33m| \\____) |\033[32m| \\____) |\033[34m _| |  | |_ \033[0m\n"
 	"\033[33m \\______.'\033[32m \\______.'\033[34m|____||____|\033[0m\n"
 	"\n"
-	"SSH manager (\033[31mv1.1.2\033[0m)\n"
+	"SSH manager (\033[31mv1.1.3\033[0m)\n"
 	"By \033[35mMaxLane\033[0m and \033[35mBadWolf\033[0m\n"
 	"\n"
 	"Feedback:\n"
@@ -96,9 +96,37 @@ const unordered_map<string, OneArgHandle> OneArgs
 //  	return true;
 // }
 
+int getterm()
+{
+	string term = getenv("TERM");
+	if (term == "xterm-kitty") return 1;
+	return 0;
+}
+
+string sshClient()
+{
+	int value = 0;
+	
+	#if WINDOWS
+		value = 0
+	#else
+		value = getterm();
+	#endif
+
+	switch (value)
+	{
+	case 0:
+		return "ssh ";
+	case 1:
+		return "kitten ssh ";
+	default:
+		return "ssh ";
+	}
+}
+
 string command(string user, string host, string port)
 {
-	return "ssh " + user + "@" + host + " -p " + port;
+	return sshClient() + user + "@" + host + " -p " + port;
 };
 
 void printList(HostsParser &hosts)


### PR DESCRIPTION
add checking $TERM os parametr
and if $TERM is kitty, change ssh to "kitten ssh"

issue explanation
[from AurWIKI](https://wiki.archlinux.org/title/Kitty#Terminal_issues_with_SSH)
Terminal issues with SSH
When kitty is used to ssh into a remote that does not have its terminfo, various issues can occur. The solution is normally to copy over the terminfo. Kitty has an ssh kitten to automate exactly this.

$ kitty +kitten ssh user@host
You may want to set it as an alias for ssh. One way to do that is to detect if the user is using Kitty, and if so, alias the ssh command. To do that, you would append the following line to your ~/.bashrc or ~/.zshrc file:

[ "$TERM" = "xterm-kitty" ] && alias ssh="kitty +kitten ssh"
If for whatever reason you are unable to install the terminfo on the remote, you can try setting TERM to something that is more likely to be present. Note that this might disable some of the terminal's features. See [OpenSSH#Connecting to a remote without the appropriate terminfo entry](https://wiki.archlinux.org/title/OpenSSH#Connecting_to_a_remote_without_the_appropriate_terminfo_entry).